### PR TITLE
Challenge: resolve puzzle issue on sendingRawTransaction

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,8 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk);
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The issue is that the code was trying to send an unsigned transaction.
A transaction must be signed first.

**How did you fix the bug?**

I did sign the transaction (with signTxn() method from the Transaction) and then pass it to sendRawTransaction method.

![Algodevs-Challenge1-output](https://github.com/algorand-coding-challenges/challenge-1/assets/5107647/55a0e242-cf81-4ecb-9c2c-a1b7be5867a5)

