### PR TITLE
fix: use signed txn with sendRawTransaction

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,9 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk);
+
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

Code tried to use algosdk.sendRawTransaction with the unsigned txn object (an algosdk.Transaction). sendRawTransaction requires an Uint8Array or Uin8Array[] as arguments and expects a signed transaction as input. 

**How did you fix the bug?**

Used txn.signTxn(sender.sk) to sign the transaction and used the returned Uint8Array of signed byte data with sendRawTransaction.

**Console Screenshot:**

<img width="550" alt="image" src="https://github.com/algorand-coding-challenges/challenge-1/assets/157974735/adfa82a2-8a2e-4d0d-830b-34affcbdca5f">
