### PR TITLE
sign transaction before submission

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,8 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const stxn = txn.signTxn(sender.sk)
+await algodClient.sendRawTransaction(stxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**
The original code had omitted a step prior to submitting the transaction to the network. As per the developer docs, a transaction needs to be signed using a private key for it to be considered as valid.

**How did you fix the bug?**
Refactored the code by introducing a step for signing the transaction using the sender's private key property and submitted the signed transaction to the network.

**Console Screenshot:**
![image](https://github.com/algorand-coding-challenges/challenge-1/assets/40172652/e84c41d3-cdc8-4037-bc44-8a33359a67ad)

