### PR TITLE
Update index.ts

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,12 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk); // Sign the transaction with sender's private key
+
+// Submit the transaction
+await algodClient.sendRawTransaction(signedTxn).do();
+    
+
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The bug was occurring in the `index.ts` file when attempting to send a payment transaction. The error message` TypeError: Argument must be byte array` was being displayed.
Before the transaction is considered valid, it must be signed by a private key.

**How did you fix the bug?**

- Used `signTxn` method to sign the transaction with the sender's private key before submitting it to the network. The signed transaction can now be submitted to the network.

- Updated the `sendRawTransaction` method to use the signed transaction (`signedTxn`) instead of the unsigned transaction (`txn`).

**Console Screenshot:**

![challenge1](https://github.com/algorand-coding-challenges/challenge-1/assets/113017737/13c1a66d-cfb7-4dc2-84e9-c8b26ddf55ca)


