### PR TITLE
* challenge 1 bug fix

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -22,14 +22,20 @@ When solved correctly, the console should print out the following:
 "Payment of 1000000 microAlgos was sent to RRYKB23LFR62G3P4SFINZDQ4FVDUNWWQ4NOF7K6TP5GO65BQCHYMNTR3CU at confirmed round 59"
 */
 const suggestedParams = await algodClient.getTransactionParams().do();
-const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: sender.addr,
-    suggestedParams,
-    to: receiver.addr,
-    amount: 1000000,
-});
+const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject(
+    {
+        from: sender.addr,
+        suggestedParams,
+        to: receiver.addr,
+        amount: 1000000,
+        note: new Uint8Array(Buffer.from('from riggy xD')),
+    }
+);
 
-await algodClient.sendRawTransaction(txn).do();
+/* the txn needed to be signed! */
+const signedTxn = txn.signTxn(sender.sk);
+
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The transaction was not signed by the sender's private key prior to the transaction being sent.

**How did you fix the bug?**

I used the .signTxn() method. This meant that the transaction was signed using the sender's private key before the transaction was sent. I looked at the algo dev docs to confirm the step-by-step process of how transactions are built and sent on Algorand.

**Console Screenshot:**
![algo challenge 1 riggy](https://github.com/algorand-coding-challenges/challenge-1/assets/96948324/e3f98f90-224c-4613-aa19-55408a3fec9a)

