### PR TITLE
added the secret key to fix tx for algorand challenge 1

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -5,6 +5,7 @@ const algodClient = algokit.getAlgoClient()
 
 // Retrieve 2 accounts from localnet kmd
 const sender = await algokit.getLocalNetDispenserAccount(algodClient)
+console.log("Sender:", sender);
 const receiver = await algokit.mnemonicAccountFromEnvironment(
     {name: 'RECEIVER', fundWith: algokit.algos(100)},
     algodClient,
@@ -24,12 +25,15 @@ When solved correctly, the console should print out the following:
 const suggestedParams = await algodClient.getTransactionParams().do();
 const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     from: sender.addr,
-    suggestedParams,
+    suggestedParams: suggestedParams,
     to: receiver.addr,
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk);
+
+
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

Missing the signer key from the sender address. 

**How did you fix the bug?**

I created the const for the signed transaction, by passing the sender.sk into signTxn(), then provided that arg to the sendRawTransaction function.

**Console Screenshot:** 
<img width="885" alt="Screen Shot 2024-03-05 at 10 35 03 PM" src="https://github.com/algorand-coding-challenges/challenge-1/assets/707142/b829ef2b-1be0-4270-aefc-249647892b06">
 