### PR TITLE
fix: missing transaction signing, incorrect raw transaction payload

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -1,14 +1,14 @@
-import algosdk  from "algosdk";
-import * as algokit from '@algorandfoundation/algokit-utils';
+import algosdk from "algosdk";
+import * as algokit from "@algorandfoundation/algokit-utils";
 
-const algodClient = algokit.getAlgoClient()
+const algodClient = algokit.getAlgoClient();
 
 // Retrieve 2 accounts from localnet kmd
-const sender = await algokit.getLocalNetDispenserAccount(algodClient)
+const sender = await algokit.getLocalNetDispenserAccount(algodClient);
 const receiver = await algokit.mnemonicAccountFromEnvironment(
-    {name: 'RECEIVER', fundWith: algokit.algos(100)},
-    algodClient,
-  )
+  { name: "RECEIVER", fundWith: algokit.algos(100) },
+  algodClient
+);
 
 /*
 TODO: edit code below
@@ -23,17 +23,21 @@ When solved correctly, the console should print out the following:
 */
 const suggestedParams = await algodClient.getTransactionParams().do();
 const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: sender.addr,
-    suggestedParams,
-    to: receiver.addr,
-    amount: 1000000,
+  from: sender.addr,
+  suggestedParams,
+  to: receiver.addr,
+  amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = algosdk.signTransaction(txn, sender.sk);
+
+await algodClient.sendRawTransaction(signedTxn.blob).do();
 const result = await algosdk.waitForConfirmation(
-    algodClient,
-    txn.txID().toString(),
-    3
+  algodClient,
+  txn.txID().toString(),
+  3
 );
 
-console.log(`Payment of ${result.txn.txn.amt} microAlgos was sent to ${receiver.addr} at confirmed round ${result['confirmed-round']}`);
+console.log(
+  `Payment of ${result.txn.txn.amt} microAlgos was sent to ${receiver.addr} at confirmed round ${result["confirmed-round"]}`
+);

--- a/challenge/package-lock.json
+++ b/challenge/package-lock.json
@@ -11,6 +11,9 @@
         "dotenv": "^16.4.1",
         "tsx": "^4.7.0"
       },
+      "devDependencies": {
+        "@types/node": "^20.11.24"
+      },
       "peerDependencies": {
         "typescript": "^5.0.0"
       }
@@ -374,6 +377,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/@types/node": {
+      "version": "20.11.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
+      "integrity": "sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/algo-msgpack-with-bigint": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/algo-msgpack-with-bigint/-/algo-msgpack-with-bigint-2.1.1.tgz",
@@ -613,6 +625,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/vlq": {
       "version": "2.0.4",

--- a/challenge/package.json
+++ b/challenge/package.json
@@ -13,5 +13,8 @@
     "algosdk": "^2.7.0",
     "dotenv": "^16.4.1",
     "tsx": "^4.7.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.24"
   }
 }

--- a/challenge/tsconfig.json
+++ b/challenge/tsconfig.json
@@ -1,18 +1,18 @@
 {
   "compilerOptions": {
-    "lib": ["ESNext"],
+    "lib": [
+      "ESNext"
+    ],
     "target": "ESNext",
     "module": "ESNext",
     "moduleDetection": "force",
     "jsx": "react-jsx",
     "allowJs": true,
-
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
-
     /* Linting */
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
- Added `signTransaction` to... sign the transaction before broadcast
- Fixed `sendRawTransaction` with the appropriate `Uint8Array` blob
- Added missing `@types/node` which will make make TS linters complain with use of `console` (bonus points?)

## Algorand Coding Challenge Submission

**What was the bug?**

The core bug was a missing transaction signing:

```ts
const signedTxn = algosdk.signTransaction(txn, sender.sk);
```

Second to this, the now signed transactions `blob` was not being sent for broadcast:

```ts
await algodClient.sendRawTransaction(signedTxn.blob).do();
```


**How did you fix the bug?**

Please see above. 


**Console Screenshot:**

<img width="937" alt="Screenshot 2024-03-06 at 08 04 47" src="https://github.com/algorand-coding-challenges/challenge-1/assets/145453/e05ed1f5-56dc-4e7b-a78f-3c0bd02ec434">


&nbsp;
✌🏾
