### PR TITLE
Fix: Add missing transaction signature

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -1,4 +1,4 @@
-import algosdk  from "algosdk";
+import algosdk from "algosdk";
 import * as algokit from '@algorandfoundation/algokit-utils';
 
 const algodClient = algokit.getAlgoClient()
@@ -6,9 +6,9 @@ const algodClient = algokit.getAlgoClient()
 // Retrieve 2 accounts from localnet kmd
 const sender = await algokit.getLocalNetDispenserAccount(algodClient)
 const receiver = await algokit.mnemonicAccountFromEnvironment(
-    {name: 'RECEIVER', fundWith: algokit.algos(100)},
+    { name: 'RECEIVER', fundWith: algokit.algos(100) },
     algodClient,
-  )
+)
 
 /*
 TODO: edit code below
@@ -29,7 +29,10 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+// Sign the transaction
+const signedTxn = txn.signTxn(sender.sk);
+
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The prepared transaction was missing the transaction sender's signature. 
This caused the following error to be thrown:

```js
LocalNet account 'RECEIVER' doesn't yet exist; created account WKIG447P5MVTKNLPLBERPIPGDJN7OFDRNYZUCHWBTX36MPVNQLDOJT4LA4 with keys stored in KMD and funding with 100 ALGOs
Transferring 100000000µALGOs from E23ZWBYFFIOUYM253ZB6EKAR4Z6WLLWAPUB3ECYWXS77O2625OLE73S5I4 to WKIG447P5MVTKNLPLBERPIPGDJN7OFDRNYZUCHWBTX36MPVNQLDOJT4LA4
Sent transaction ID UH2GCEP724KTHO7BVS3DG2THKSUGBBLTC47AKGN5UM5R2XHBLY4Q pay from E23ZWBYFFIOUYM253ZB6EKAR4Z6WLLWAPUB3ECYWXS77O2625OLE73S5I4
/algorand-challanges/challenge-1/challenge/node_modules/algosdk/src/client/v2/algod/sendRawTransaction.ts:41
      throw new TypeError('Argument must be byte array');
            ^

TypeError: Argument must be byte array
    at SendRawTransaction (/algorand-challanges/challenge-1/challenge/node_modules/algosdk/src/client/v2/algod/sendRawTransaction.ts:41:13)
    at AlgodClient.sendRawTransaction (/algorand-challanges/challenge-1/challenge/node_modules/algosdk/src/client/v2/algod/algod.ts:140:12)
    at <anonymous> (/algorand-challanges/challenge-1/challenge/index.ts:32:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v20.8.0
```

**How did you fix the bug?**

Signed the prepared transaction with the `txn.signTxn(sender.sk)` function, and passed its return value into `algodClient.sendRawTransaction(signedTxn).do()`. By doing so, a correct payment transaction could be propagated to the network.

**Console Screenshot:**

<img width="678" alt="image" src="https://github.com/algorand-coding-challenges/challenge-1/assets/162426140/411b4f27-61cf-45c5-8c0f-6a2edad1e0e7">
