### PR TITLE
Bug fix

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -1,14 +1,15 @@
-import algosdk  from "algosdk";
-import * as algokit from '@algorandfoundation/algokit-utils';
+import algosdk from "algosdk";
+import * as algokit from "@algorandfoundation/algokit-utils";
 
-const algodClient = algokit.getAlgoClient()
+const algodClient = algokit.getAlgoClient();
+const indexer = algokit.getAlgoIndexerClient();
 
 // Retrieve 2 accounts from localnet kmd
-const sender = await algokit.getLocalNetDispenserAccount(algodClient)
+const sender = await algokit.getLocalNetDispenserAccount(algodClient);
 const receiver = await algokit.mnemonicAccountFromEnvironment(
-    {name: 'RECEIVER', fundWith: algokit.algos(100)},
-    algodClient,
-  )
+  { name: "RECEIVER", fundWith: algokit.algos(100) },
+  algodClient
+);
 
 /*
 TODO: edit code below
@@ -22,18 +23,23 @@ When solved correctly, the console should print out the following:
 "Payment of 1000000 microAlgos was sent to RRYKB23LFR62G3P4SFINZDQ4FVDUNWWQ4NOF7K6TP5GO65BQCHYMNTR3CU at confirmed round 59"
 */
 const suggestedParams = await algodClient.getTransactionParams().do();
+// const balance = await indexer?.lookupAccountByID(sender.addr).do();
+// console.log({balance})
 const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: sender.addr,
-    suggestedParams,
-    to: receiver.addr,
-    amount: 1000000,
+  from: sender.addr,
+  suggestedParams,
+  to: receiver.addr,
+  amount: 1000000,
 });
+const signTx = algosdk.signTransaction(txn, sender.sk);
+await algodClient.sendRawTransaction(signTx.blob).do();
 
-await algodClient.sendRawTransaction(txn).do();
 const result = await algosdk.waitForConfirmation(
-    algodClient,
-    txn.txID().toString(),
-    3
+  algodClient,
+  txn.txID().toString(),
+  3
 );
 
-console.log(`Payment of ${result.txn.txn.amt} microAlgos was sent to ${receiver.addr} at confirmed round ${result['confirmed-round']}`);
+console.log(
+  `Payment of ${result.txn.txn.amt} microAlgos was sent to ${receiver.addr} at confirmed round ${result["confirmed-round"]}`
+);


### PR DESCRIPTION
- Added ability to sign transaction before broadcasting raw
- Replaced raw Uint8 array passed to `sendRawTransaction` with blob returned from sign transaction

## Algorand Coding Challenge Submission

**Improper transaction blob sent as raw transaction**

The script file contained an improper parameter passed to `algodClient.sendRawTransaction` .

**How did you fix the bug?**

To fix the bug I passed the output from this method call
```js
const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
  from: sender.addr,
  suggestedParams,
  to: receiver.addr,
  amount: 1000000,
});
```
Into the input of a new method
```js
const signTx = algosdk.signTransaction(txn, sender.sk);
```
The output returned was in turn passed to the input of the method

```js
await algodClient.sendRawTransaction(signTx.blob).do();
```

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/challenge-1/assets/63968702/b252b958-c57f-4527-91e9-a16c787b474e)

