### PR TITLE
[FIX] The transaction was'nt signed before being sent

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -1,5 +1,5 @@
-import algosdk  from "algosdk";
 import * as algokit from '@algorandfoundation/algokit-utils';
+import algosdk from "algosdk";
 
 const algodClient = algokit.getAlgoClient()
 
@@ -29,7 +29,7 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+await algodClient.sendRawTransaction(txn.signTxn(sender.sk)).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

We were trying to send an unsigned transaction, represented by a PaymentTransaction object, instead of a signed transaction, stored in byte array.
That's why there was the error 'Argument must be byte array', the sendRawTransaction need a byte array argument.

**How did you fix the bug?**

I called the signTxn function on the transaction. It take a secret key, I used the key of the dispenser account, and it returns the transaction signed in the form of a byte array.

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/challenge-1/assets/162464577/4125058a-2327-4038-9e8f-e0244a030477)

