### PR TITLE
Fixed the bug 🐞

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,9 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const stxn = algosdk.signTransaction(txn, sender.sk);
+
+await algodClient.sendRawTransaction(stxn.blob).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The transaction object `txn` had not yet been signed before passing it into `sendRawTransaction`.

**How did you fix the bug?**

Using `algosdk.signTransaction()` with unsigned `txn` object and the sender's secret key `sender.sk` produced a signed transaction `stxn` that can be sent.

**Console Screenshot:**

Attached
