### PR TITLE
Fixing the bug

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,9 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk);
+
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

Before the transaction is considered valid, it must be signed by a private key. In this case it wasn't being signed. 

**How did you fix the bug?**

Following the documentation, I added the code to sign the transaction:
const signedTxn = txn.signTxn(sender.sk);

**Screenshot of your terminal showing the logged sentence.**

![imagen](https://github.com/algorand-coding-challenges/challenge-1/assets/63990513/92b05f6c-5d8a-49ef-a255-3606754de057)
