### PR TITLE
transaction bug fix

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,9 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk);
+
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

Transaction was not signed by senders's private key.

**How did you fix the bug?**

call signTxn method prior to sending raw transaction.

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/challenge-1/assets/142668625/92d74596-7da2-423f-98b7-0dd044c51eaa)
