### PR TITLE
Added signed transaction , fixed the bug successfully

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,11 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+// sign transaction is not mentioned, added it here
+
+const signedTxn: Uint8Array = txn.signTxn(sender.sk);
+await algodClient.sendRawTransaction(signedTxn).do()
+
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

the transaction is not signed before validation, it should be signed by the private key. In index.ts it was not mentioned before that needs to be fixed.

**How did you fix the bug?**

By taking help from my previous code snippets and documentation available on the Algorand Devportal, it helped me here to find the bug!

const signedTxn: Uint8Array = txn.signTxn(sender.sk);
await algodClient.sendRawTransaction(signedTxn).do()

**Console Screenshot:**

![challenge 1](https://github.com/algorand-coding-challenges/challenge-1/assets/107026627/da9ff21d-1963-4384-ad27-3fa4016c9b3c)

