### PR TITLE
Bug: Fix transaction send error

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -28,8 +28,8 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     to: receiver.addr,
     amount: 1000000,
 });
-
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = await algokit.signTransaction(txn, sender);
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**
The bug was an error that was thrown because an attempt was made to publish an unsigned transaction to the network. The transaction object was created with the correct credentials, but the transaction was not signed by the sender before being published to the network.

**How did you fix the bug?**
In order to fix the bug, I added a line of code that signed the transaction with the signTransaction method provided by algokit, passing the Account object of the sender to the method and also the transaction to be signed. I proceeded to pass the result of the signTransaction method to the method that publishes the transaction to the network and voila, it worked!

**Console Screenshot:**
![image](https://github.com/algorand-coding-challenges/challenge-1/assets/68940073/6ae2008d-3772-4556-8c34-fd2d2e06c38b)

