### PR TITLE
solved the challenge

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,9 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk);
+await algodClient.sendRawTransaction(signedTxn).do();
+
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**
Any Transaction needed to be signed before sending to the network to confirm the sender identity,
here the transaction hasn't signed with sender private key before sending to the network. 

**How did you fix the bug?**
just signed the transaction using sender private key before sending the transaction to the network

**Console Screenshot:**
![Screenshot 2024-03-08 103421](https://github.com/algorand-coding-challenges/challenge-1/assets/110321560/f55b1bdc-09b9-4c0f-819a-a2e12108b9c5)

