### PR TITLE
fixed transaction by signing with private key

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -28,8 +28,8 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     to: receiver.addr,
     amount: 1000000,
 });
-
-await algodClient.sendRawTransaction(txn).do();
+const signedTransaction = txn.signTxn(sender.sk);
+await algodClient.sendRawTransaction(signedTransaction).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The sendRawTransaction() expects a Uint8 array but we provided the naked transaction as an argument

**How did you fix the bug?**

The transaction has to signed by the sender's private key available through sender.sk which converts the semantic txn object into a cryptic Uint8 array which is signed. I then updated the argument with the signed txn

**Console Screenshot:**

![challenge-1-ss](https://github.com/algorand-coding-challenges/challenge-1/assets/109805377/22cfa478-d808-4247-9140-40ffce14fb80)

