### PR TITLE
Sign the transaction using the sender's secret key

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -28,8 +28,9 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     to: receiver.addr,
     amount: 1000000,
 });
+const signedTxn = txn.signTxn(sender.sk);
 
-await algodClient.sendRawTransaction(txn).do();
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The previous code attempted to submit an unsigned transaction.

**How did you fix the bug?**

* Signed the transaction using the sender's secret key
* Submitted the signed transaction

**Console Screenshot:**

![image](https://github.com/algorand-coding-challenges/challenge-1/assets/1091843/91ba4865-6796-48b7-ae89-d27cf8571563)
