### PR TITLE
:bug: Signing transaction before sending

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,9 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk);
+
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The transaction wasn't signed before sending.

**How did you fix the bug?**

Signed the transaction.

**Console Screenshot:**

![af_challenge_1_screenshot](https://github.com/algorand-coding-challenges/challenge-1/assets/109921828/1ddb2d99-6c4d-4db6-b887-df6363b0e3bd)

