### PR TITLE
fixed the bug

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,8 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk);
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**
The bug was that in the index.ts file, the transaction wasn't being signed before sending which was creating the TypeError: Argument must be byte array error. 

![image](https://github.com/algorand-coding-challenges/challenge-1/assets/91242573/821ba09e-ed63-44ef-94f2-7f5d5324b332)


**How did you fix the bug?**
I fixed the bug by signing the transaction before sending it.

![image](https://github.com/algorand-coding-challenges/challenge-1/assets/91242573/38ea4173-dffe-404c-8bc1-2b9d5c886d87)

