### PR TITLE
Fix sending payment transaction

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -28,8 +28,9 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     to: receiver.addr,
     amount: 1000000,
 });
+const signedTxn = txn.signTxn(sender.sk);
 
-await algodClient.sendRawTransaction(txn).do();
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**
Unsigned payment transaction was provided as an argument to the `sendRawTransaction()` function resulting in `TypeError: Argument must be byte array` error.

**How did you fix the bug?**
Transaction was signed with the sender's private key before sending.

**Console Screenshot:**
![console_screenshot1](https://github.com/algorand-coding-challenges/challenge-1/assets/114208957/27f35f8a-ba32-4124-89c4-0f2dad4da390)

