### PR TITLE
Solved: Algorand Challenge 1

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,9 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk);
+
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

<!-- Provide a clear and concise description of the bug. -->

The bug was that we were trying to submit a transaction without signing it with the private key of the sending address, so we obtained that "TypeError" because there was a mismatch regarding the datatype that the method "sendRawTransaction" was expected to handle.

**How did you fix the bug?**

<!-- Explain the steps you took to fix the bug. -->

To fix the bug, I looked at the documentation for the type returned back by the function "makePaymentTxnWithSuggestedParamsFromObject", so I understood that I was dealing with the type "algosdk.Transaction" and, before submitting this kind of transaction, I had to sign that transaction using the secret key belonging to the Algorand address of the sender; this way I've obtained the kind of object that the method "sendRawTransaction" is supposed to handle in input.

**Console Screenshot:**

<!-- Attach a screenshot of your console showing the result specified in the README. -->

![image](https://github.com/algorand-coding-challenges/challenge-1/assets/55320885/c240f49e-324d-4b56-b304-63fb7d9b0577)
