### PR TITLE
Add line to sign transaction

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,9 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk);
+
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**
The transaction was not signed by the sender before it was submitted.

**How did you fix the bug?**
Following the example specified [in this documentation](https://developer.algorand.org/docs/sdks/javascript/#sign-first-transaction), the transaction `txn` was signed with the method `.signTxn()` using the private key `sender.sk`.

**Console Screenshot:**
![Screenshot 2024-03-12 at 10 01 19 PM](https://github.com/algorand-coding-challenges/challenge-1/assets/58460790/16d017ee-2e26-40d8-b2a1-841d1638d0fc)