### PR TITLE
Added signTxn() to sign transaction and resolve bug; added node type definitions

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,8 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk);
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),

--- a/challenge/package-lock.json
+++ b/challenge/package-lock.json
@@ -11,6 +11,9 @@
         "dotenv": "^16.4.1",
         "tsx": "^4.7.0"
       },
+      "devDependencies": {
+        "@types/node": "^20.11.26"
+      },
       "peerDependencies": {
         "typescript": "^5.0.0"
       }
@@ -374,6 +377,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/@types/node": {
+      "version": "20.11.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.26.tgz",
+      "integrity": "sha512-YwOMmyhNnAWijOBQweOJnQPl068Oqd4K3OFbTc6AHJwzweUwwWG3GIFY74OKks2PJUDkQPeddOQES9mLn1CTEQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/algo-msgpack-with-bigint": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/algo-msgpack-with-bigint/-/algo-msgpack-with-bigint-2.1.1.tgz",
@@ -613,6 +625,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/vlq": {
       "version": "2.0.4",

--- a/challenge/package.json
+++ b/challenge/package.json
@@ -13,5 +13,8 @@
     "algosdk": "^2.7.0",
     "dotenv": "^16.4.1",
     "tsx": "^4.7.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.26"
   }
 }


### PR DESCRIPTION
i. The sample Algorand script was failing, giving the error "TypeError: Argument must be byte array"
ii. The original code attempted to send the transaction txn without signing it ("await algodClient.sendRawTransaction(txn).do();" statement on line 32)
  - I added the line const signedTxn = txn.signTxn(sender.sk) which signs the transaction and also converts it to a byte array.
  - I also corrected the original sendRawTransaction() statement to use the signed transaction instead of the original unsigned transaction txn (await algodClient.sendRawTransaction(signedTxn).do();)
iii. ![Screenshot from 2024-03-13 07-22-07](https://github.com/algorand-coding-challenges/challenge-1/assets/8784896/7ef83dfc-6b75-4c4c-91d2-d77c320b6c7b)

FYI the "Sign First Transaction" section under the "Your First Transaction" page at https://developer.algorand.org/docs/sdks/javascript/ of the Algorand developer portal documentation calls the private key property of an account "privateKey" and not "sk".
