### PR TITLE
🔨 Transaction signing by sender

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -1,14 +1,14 @@
-import algosdk  from "algosdk";
-import * as algokit from '@algorandfoundation/algokit-utils';
+import algosdk from "algosdk";
+import * as algokit from "@algorandfoundation/algokit-utils";
 
-const algodClient = algokit.getAlgoClient()
+const algodClient = algokit.getAlgoClient();
 
 // Retrieve 2 accounts from localnet kmd
-const sender = await algokit.getLocalNetDispenserAccount(algodClient)
+const sender = await algokit.getLocalNetDispenserAccount(algodClient);
 const receiver = await algokit.mnemonicAccountFromEnvironment(
-    {name: 'RECEIVER', fundWith: algokit.algos(100)},
-    algodClient,
-  )
+  { name: "RECEIVER", fundWith: algokit.algos(100) },
+  algodClient
+);
 
 /*
 TODO: edit code below
@@ -23,17 +23,19 @@ When solved correctly, the console should print out the following:
 */
 const suggestedParams = await algodClient.getTransactionParams().do();
 const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: sender.addr,
-    suggestedParams,
-    to: receiver.addr,
-    amount: 1000000,
+  from: sender.addr,
+  suggestedParams,
+  to: receiver.addr,
+  amount: 1000000,
 });
-
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk);
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
-    algodClient,
-    txn.txID().toString(),
-    3
+  algodClient,
+  txn.txID().toString(),
+  3
 );
 
-console.log(`Payment of ${result.txn.txn.amt} microAlgos was sent to ${receiver.addr} at confirmed round ${result['confirmed-round']}`);
+console.log(
+  `Payment of ${result.txn.txn.amt} microAlgos was sent to ${receiver.addr} at confirmed round ${result["confirmed-round"]}`
+);


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

<!-- Provide a clear and concise description of the bug. -->
The transaction wasn't being signed by the sender before broadcasting the transaction to the network,

**How did you fix the bug?**

<!-- Explain the steps you took to fix the bug. -->
I read Algorand's documentation before, and I knew transactions had to be signed before being sent. I solved this by signing the transaction with the sender's private key and then sending the signed transaction. The transaction was signed by using the `.signTxn()` method with the sender's private key.

**Console Screenshot:**

<!-- Attach a screenshot of your console showing the result specified in the README. -->
![image](https://github.com/algorand-coding-challenges/challenge-1/assets/24660804/9c883a82-e37c-42c7-b5e5-3e0ebc63ff9b)
