### PR TITLE
Challenge submission

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,8 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const stxn = algosdk.signTransaction(txn, sender.sk);
+await algodClient.sendRawTransaction(stxn.blob).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**
sendRawTransaction is presented with a transaction blob while expecting a signed transaction blob.

**How did you fix the bug?**
Signed the transaction with the sender's secret key before calling the method sendRawTransaction.
The sendRawTransaction argument was changed to the signed transaction blob.

**Console Screenshot:**
![image](https://github.com/algorand-coding-challenges/challenge-1/assets/13601336/5faf1a6b-be05-4efc-954b-b8c8db3927c3)
