### PR TITLE
solved the bug

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -28,8 +28,8 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     to: receiver.addr,
     amount: 1000000,
 });
-
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk);
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

In the file index.ts, when we were running the project it is giving the TypeError: Argument must be byte array. We were getting the error because the transaction was not getting signed before happening.

**How did you fix the bug?**

I fixed the bug by signing the transaction. 

**Console Screenshot:**

![Screenshot 2024-03-15 140310](https://github.com/algorand-coding-challenges/challenge-1/assets/153931255/b43a69aa-da29-4c4e-a2be-c9e232b694c1)

![Screenshot 2024-03-15 150650](https://github.com/algorand-coding-challenges/challenge-1/assets/153931255/c43933a2-eced-4f0d-8886-dd9f2838d955)
