### PR TITLE
Algorand Coding Challenge 1

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,9 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk)
+
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
Fixed the txn that was failing

## Algorand Coding Challenge Submission

**What was the bug?**

method was failing due to the return type not matching Unit8Array
this was due to the txn not being signed by the sk

**How did you fix the bug?**

we signed the txn with the sk and that lead to the expected parameter passing as the txn was now valid

**Console Screenshot:**

<img width="1077" alt="Screenshot 2024-03-15 at 11 37 02 PM" src="https://github.com/algorand-coding-challenges/challenge-1/assets/46083510/3849f66e-c082-45f4-a1b8-d168d3dd5457">
