### PR TITLE
Challenge 1 is solved by transaction Signing by the sender

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -1,4 +1,4 @@
-import algosdk  from "algosdk";
+import algosdk from "algosdk";
 import * as algokit from '@algorandfoundation/algokit-utils';
 
 const algodClient = algokit.getAlgoClient()
@@ -6,9 +6,9 @@ const algodClient = algokit.getAlgoClient()
 // Retrieve 2 accounts from localnet kmd
 const sender = await algokit.getLocalNetDispenserAccount(algodClient)
 const receiver = await algokit.mnemonicAccountFromEnvironment(
-    {name: 'RECEIVER', fundWith: algokit.algos(100)},
+    { name: 'RECEIVER', fundWith: algokit.algos(100) },
     algodClient,
-  )
+)
 
 /*
 TODO: edit code below
@@ -29,7 +29,9 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk);
+await algodClient.sendRawTransaction(signedTxn).do();
+
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The bug arose from passing an unsigned payment transaction as an argument to the sendRawTransaction() function, triggering a TypeError: Argument must be byte array error.

**How did you fix the bug?**

To address the issue, the transaction was signed using the sender's private key prior to transmission.

**Console Screenshot:**

![Screenshot 2024-03-16 005518](https://github.com/algorand-coding-challenges/challenge-1/assets/124354810/73d859bd-f892-43d2-b6f2-b6a87763a8ea)