### PR TITLE
commit

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,9 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk)
+
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

the transaction wasn't signed before it was submitted to the network


**How did you fix the bug?**

I used the method "signTxn" to sign the transaction by the private key of the sender


**Console Screenshot:**

![challenge 1](https://github.com/algorand-coding-challenges/challenge-1/assets/58332840/3276ab22-6dc1-47fb-aa57-6e7c437003fe)

