### PR TITLE
fix transaction bug

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,9 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn = txn.signTxn(sender.sk);
+
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

We are trying to send an unsigned transaction.

**How did you fix the bug?**

I signed the transaction with the sender secret key before sending it.

**Console Screenshot:**

![Screenshot 2024-03-17 121156](https://github.com/algorand-coding-challenges/challenge-1/assets/122732986/22767916-6f31-4722-b2f3-7ba8445c1c60)
