### PR TITLE
CRYSTAL CLEAR SOLUTION 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Here is a hint for you: https://developer.algorand.org/docs/sdks/javascript/
    1. What was the problem?
    2. How did you solve the problem?
    3. Screenshot of your terminal showing the logged sentence. `Payment of 1000000 microAlgos was sent to [receiver's address]`
+  
+   ![image](https://github.com/PsychCharge/challenge-1/assets/163745912/3c2fbe56-3671-4412-9349-467a63c99c48)
+
 
 ## Checkpoint 5: 🏆 Claim your certificate of completion NFT! 🎓
 

--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,8 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const signedTxn: Uint8Array = txn.signTxn(sender.sk);
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),

--- a/challenge/tsconfig.json
+++ b/challenge/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ESNext"],
+    "lib": ["DOM","ESNext"],
     "target": "ESNext",
     "module": "ESNext",
     "moduleDetection": "force",
@@ -8,7 +8,7 @@
     "allowJs": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "Node",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

Forwarding the Transaction without signing it which defies the rule of authenticity for the transaction within Algorand's Network.

**How did you fix the bug?**

Basically, We are digitally Signing the Transaction before sending the Algorand's Network using the Algod client by just creating a constant called "signedTxn" and then passing it as a datatype while sending the transaction Record.

**Console Screenshot:**

![Screenshot 2024-03-17 202121](https://github.com/algorand-coding-challenges/challenge-1/assets/163745912/6f933850-6471-455d-bc6a-bcd0f737c06e)


<!-- Attach a screenshot of your console showing the result specified in the README. -->
