### PR TITLE
Solve the challenge

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -27,9 +27,12 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     suggestedParams,
     to: receiver.addr,
     amount: 1000000,
-});
 
-await algodClient.sendRawTransaction(txn).do();
+});
+const signedTxn = txn.signTxn(sender.sk);
+console.log({ txn, signedTxn });
+
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**
The transaction is not signed, so the algorand js sdk throws a error because he is expecting a array of bytes representing the signed transaction, and receipts a plain Transaction object.

<!-- Provide a clear and concise description of the bug. -->

**How did you fix the bug?**
I went to the sdk repository and start investigating
https://github.com/algorand/js-algorand-sdk/blob/a4eccfbeaac94f09d161aee45958f8b27923546c/src/client/v2/algod/sendRawTransaction.ts#L41
after inspect the examples I conclude the param were not in the correct format. (TS helped a lot too)

<!-- Explain the steps you took to fix the bug. -->

**Console Screenshot:**
![image](https://github.com/algorand-coding-challenges/challenge-1/assets/2827894/38d7b7c7-6c57-48f2-830a-914ef4e2977d)

<!-- Attach a screenshot of your console showing the result specified in the README. -->
