### PR TITLE
fix: sign transaction and pass blob to sendRawTransaction

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -29,7 +29,10 @@ const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+const blob = txn.signTxn(sender.sk);
+
+await algodClient.sendRawTransaction(blob).do();
+
 const result = await algosdk.waitForConfirmation(
     algodClient,
     txn.txID().toString(),


### PR DESCRIPTION
## Algorand Coding Challenge Submission

**What was the bug?**

The bug was that the transaction was not being signed, and it was passing the txn object and not the blob to sendRawTransaction

**How did you fix the bug?**

I fixed the bug by signing the transaction by the sender and passing the blob returned by txn.signTxn to the sendRawTransaction method.

**Console Screenshot:**

<img width="646" alt="Screenshot 2024-04-07 at 07 59 14" src="https://github.com/algorand-coding-challenges/challenge-1/assets/57917137/7d496137-7ea0-447c-9af3-88c3281bd216">

