### PR TITLE
Signing transaction

### DIFF
--- a/challenge/index.ts
+++ b/challenge/index.ts
@@ -1,14 +1,14 @@
-import algosdk  from "algosdk";
-import * as algokit from '@algorandfoundation/algokit-utils';
+import algosdk from "algosdk";
+import * as algokit from "@algorandfoundation/algokit-utils";
 
-const algodClient = algokit.getAlgoClient()
+const algodClient = algokit.getAlgoClient();
 
 // Retrieve 2 accounts from localnet kmd
-const sender = await algokit.getLocalNetDispenserAccount(algodClient)
+const sender = await algokit.getLocalNetDispenserAccount(algodClient);
 const receiver = await algokit.mnemonicAccountFromEnvironment(
-    {name: 'RECEIVER', fundWith: algokit.algos(100)},
-    algodClient,
-  )
+  { name: "RECEIVER", fundWith: algokit.algos(100) },
+  algodClient
+);
 
 /*
 TODO: edit code below
@@ -23,17 +23,22 @@ When solved correctly, the console should print out the following:
 */
 const suggestedParams = await algodClient.getTransactionParams().do();
 const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: sender.addr,
-    suggestedParams,
-    to: receiver.addr,
-    amount: 1000000,
+  from: sender.addr,
+  suggestedParams,
+  to: receiver.addr,
+  amount: 1000000,
 });
 
-await algodClient.sendRawTransaction(txn).do();
+// transaction is not yet signed, signing it with sender's sk
+const signedTxn = txn.signTxn(sender.sk);
+
+await algodClient.sendRawTransaction(signedTxn).do();
 const result = await algosdk.waitForConfirmation(
-    algodClient,
-    txn.txID().toString(),
-    3
+  algodClient,
+  txn.txID().toString(),
+  3
 );
 
-console.log(`Payment of ${result.txn.txn.amt} microAlgos was sent to ${receiver.addr} at confirmed round ${result['confirmed-round']}`);
+console.log(
+  `Payment of ${result.txn.txn.amt} microAlgos was sent to ${receiver.addr} at confirmed round ${result["confirmed-round"]}`
+);


### PR DESCRIPTION
BUG: the transaction was not signed before being the broadcast.
FIX: Signing the transaction using the senders secret key

Screenshot:
![image](https://github.com/algorand-coding-challenges/challenge-1/assets/1016541/f6a0b723-39db-4086-9923-8f64979d2b64)


## Algorand Coding Challenge Submission

**What was the bug?**

<!-- Provide a clear and concise description of the bug. -->

**How did you fix the bug?**

<!-- Explain the steps you took to fix the bug. -->

**Console Screenshot:**

<!-- Attach a screenshot of your console showing the result specified in the README. -->
